### PR TITLE
minor bug causing reportTime option to always be true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ var InfluxUdp = function influxUdp(opts) {
     this.host = opts.host || '127.0.0.1';
     this.port = opts.port || 4444;
     this.protocol = opts.protocol || 'line';
-    this.reportTime = opts.reportTime || true;
+    this.reportTime = opts.reportTime == undefined ? true : opts.reportTime;
     this.socket = dgram.createSocket(opts.socketType || 'udp4');
     this.timeScale = timeScales[opts.timeScale] || 1;
 


### PR DESCRIPTION
Do we want this to default to `true`?

Influx version 0.10 appears to insert timestamps even if you don't send them, so might calling this option `reportClientTime` might make this behavior more intuitive?
