### PR TITLE
2.0.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+    parserOptions: {
+        ecmaVersion: 6
+    },
+    env: {
+        es6: true,
+        mocha: true,
+        node: true
+    },
+    'extends': 'eslint:recommended',
+    rules: {
+        'brace-style': [2, '1tbs', { allowSingleLine: true }],
+        'comma-dangle': [2, 'never'],
+        'dot-notation': 2,
+        'no-array-constructor': 2,
+        'no-console': 0,
+        'no-fallthrough': 0,
+        'no-inline-comments': 1,
+        'no-trailing-spaces': 2,
+        'object-curly-spacing': [2, 'always'],
+        quotes: [2, 'single'],
+        semi: [2, 'always']
+    }
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ node_js:
   - 6
   - 7
   - 8
+
+ notifications:
+   slack:
+     rooms:
+       - secure: "j1lMyugk8LysW+JZhPyyKhd9n6crIVi5j6aRJHY9FdcifbCtitp8a62KJh1bTUOqMW8A5uktNK+z6F4Zx3I4vWYa7K+6qlCP/1AxoNFfVzdImBeqR9eN3q4BGP6kw3x06xYJNY8Y/uqeOjdy9BhR9f5A2pj/YQ6jUWmH9d5I6zQ="
+     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+after_success:
+  - npm run coveralls
+
+before_script:
+  - npm i -g eslint
+  - eslint .
+
+language: node_js
+
+node_js:
+  - 4
+  - 6
+  - 7
+  - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ node_js:
   - 7
   - 8
 
- notifications:
-   slack:
-     rooms:
-       - secure: "j1lMyugk8LysW+JZhPyyKhd9n6crIVi5j6aRJHY9FdcifbCtitp8a62KJh1bTUOqMW8A5uktNK+z6F4Zx3I4vWYa7K+6qlCP/1AxoNFfVzdImBeqR9eN3q4BGP6kw3x06xYJNY8Y/uqeOjdy9BhR9f5A2pj/YQ6jUWmH9d5I6zQ="
-     on_success: always
+notifications:
+  slack:
+    rooms:
+      - secure: "j1lMyugk8LysW+JZhPyyKhd9n6crIVi5j6aRJHY9FdcifbCtitp8a62KJh1bTUOqMW8A5uktNK+z6F4Zx3I4vWYa7K+6qlCP/1AxoNFfVzdImBeqR9eN3q4BGP6kw3x06xYJNY8Y/uqeOjdy9BhR9f5A2pj/YQ6jUWmH9d5I6zQ="
+    on_success: always

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-influx-udp
 
 [![Build Status](https://travis-ci.org/mediocre/node-influx-udp.svg?branch=master)](https://travis-ci.org/mediocre/node-influx-udp)
-
+[![Coverage Status](https://coveralls.io/repos/github/mediocre/node-influx-udp/badge.svg?branch=master)](https://coveralls.io/github/mediocre/node-influx-udp?branch=master)
 
 What
 ----

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-node-influx-udp
-==========
+# node-influx-udp
+
+[![Build Status](https://travis-ci.org/mediocre/node-influx-udp.svg?branch=master)](https://travis-ci.org/mediocre/node-influx-udp)
+
 
 What
 ----

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,12 +19,13 @@ var InfluxUdp = function influxUdp(opts) {
     this.socketType = opts.socketType || 'udp4';
     this.timeScale = timeScales[opts.timeScale] || 1;
 
-    this.encode = this.protocol == 'line' ? this.lineProtocol :
+    this.encode = this.protocol == 'udp' ? this.lineProtocol :
+                  this.protocol == 'line' ? this.lineProtocol :
                   this.protocol == 'json' ? this.jsonProtocol :
                   undefined;
 
     if (!this.encode) {
-        throw new Error('Invalid protocol: ' + this.encode);
+        throw new Error('Invalid protocol: ' + this.protocol);
     }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,9 +32,17 @@ var InfluxUdp = function influxUdp(opts) {
 InfluxUdp.prototype.lineProtocol = function(points) {
     var self = this;
 
-    function convertObjectToKV(obj) {
+    function convertObjectToKV(obj, quoteStrings) {
         return Object.keys(obj).map(function(key) {
-            return key + '=' + obj[key]
+            var value = obj[key]
+            if(typeof value === 'string') {
+                if(quoteStrings) {
+                    value = '"' + value + '"'
+                } else {
+                    value = value.replace(/ /g, '\\ ').replace(/,/g, '\\,').replace(/=/g, '\\=')
+                }
+            }
+            return key + '=' + value
         }).join(',');
     }
 
@@ -46,7 +54,7 @@ InfluxUdp.prototype.lineProtocol = function(points) {
             point.tags ? ',' : '',
             convertObjectToKV(point.tags || {}),
             ' ',
-            convertObjectToKV(point.values),
+            convertObjectToKV(point.values, true),
             self.reportTime ? ' ' + (time * self.timeScale) : ''
         ].join('');
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var dgram = require('dgram');
-var util = require('util');
 
 var _ = require('lodash');
 
@@ -34,15 +33,17 @@ InfluxUdp.prototype.lineProtocol = function(points) {
 
     function convertObjectToKV(obj, quoteStrings) {
         return Object.keys(obj).map(function(key) {
-            var value = obj[key]
-            if(typeof value === 'string') {
-                if(quoteStrings) {
-                    value = '"' + value + '"'
+            var value = obj[key];
+
+            if (typeof value === 'string') {
+                if (quoteStrings) {
+                    value = `"${value}"`;
                 } else {
-                    value = value.replace(/ /g, '\\ ').replace(/,/g, '\\,').replace(/=/g, '\\=')
+                    value = value.replace(/ /g, '\\ ').replace(/,/g, '\\,').replace(/=/g, '\\=');
                 }
             }
-            return key + '=' + value
+
+            return key + '=' + value;
         }).join(',');
     }
 
@@ -68,7 +69,7 @@ InfluxUdp.prototype.lineProtocol = function(points) {
             );
         }, []).join('\n')
     );
-}
+};
 
 InfluxUdp.prototype.jsonProtocol = function(points) {
     function keysToValues(columns) {
@@ -109,7 +110,7 @@ InfluxUdp.prototype.jsonProtocol = function(points) {
     }
 
     return new Buffer(JSON.stringify(results));
-}
+};
 
 InfluxUdp.prototype.send = function influxSend(points) {
     var message = this.encode(points);
@@ -126,22 +127,26 @@ InfluxUdp.prototype.writePoints = function(seriesName, points, options, cb) {
                    undefined;
 
     var data = {};
+
     data[seriesName] = points.map(function(point) {
         var v = point[0],
             value = _.isObject(v) && !_.isUndefined(v.value) ? v : { value: v },
             time = value.time;
-        
+
         delete value.time;
 
         return {
             values: value,
             tags: point[1],
             time: time
-        }
+        };
     });
+
     this.send(data);
 
-    if (callback) callback();
+    if (callback) {
+        callback();
+    }
 };
 
 module.exports = InfluxUdp;

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ var InfluxUdp = function influxUdp(opts) {
     this.host = opts.host || '127.0.0.1';
     this.port = opts.port || 4444;
     this.protocol = opts.protocol || 'line';
-    this.reportTime = opts.reportTime || true;
+    this.reportTime = opts.reportTime == undefined ? true : opts.reportTime;
     this.socketType = opts.socketType || 'udp4';
     this.timeScale = timeScales[opts.timeScale] || 1;
 
@@ -62,10 +62,10 @@ InfluxUdp.prototype.lineProtocol = function(points) {
     return new Buffer(
         _.reduce(points, function(arr, value, key) {
             var convert = _.bind(_.partial(convertPointToLine, key), self);
-            if (Array.isArray(value)) {
-                return arr.concat(value.map(convert));
-            }
-            return arr.concat(convertPointToLine(key, value));
+            return arr.concat(
+                Array.isArray(value) ? value.map(convert) :
+                                       convertPointToLine(key, value)
+            );
         }, []).join('\n')
     );
 }
@@ -118,6 +118,30 @@ InfluxUdp.prototype.send = function influxSend(points) {
     socket.send(message, 0, message.length, this.port, this.host, function () {
         socket.close();
     });
+};
+
+InfluxUdp.prototype.writePoints = function(seriesName, points, options, cb) {
+    var callback = (typeof options == 'function') ? options :
+                   (typeof cb == 'function') ? cb :
+                   undefined;
+
+    var data = {};
+    data[seriesName] = points.map(function(point) {
+        var v = point[0],
+            value = _.isObject(v) && !_.isUndefined(v.value) ? v : { value: v },
+            time = value.time;
+        
+        delete value.time;
+
+        return {
+            values: value,
+            tags: point[1],
+            time: time
+        }
+    });
+    this.send(data);
+
+    if (callback) callback();
 };
 
 module.exports = InfluxUdp;

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,14 @@ InfluxUdp.prototype.lineProtocol = function(points) {
 }
 
 InfluxUdp.prototype.jsonProtocol = function(points) {
+    function keysToValues(columns) {
+        return function(values) {
+            return columns.map(function(column) {
+                return values[column];
+            });
+        };
+    }
+
     var results = [];
 
     for (var name in points) {
@@ -88,19 +96,11 @@ InfluxUdp.prototype.jsonProtocol = function(points) {
             });
         }
 
-        result.points = values.map(this.keysToValues(result.columns));
+        result.points = values.map(keysToValues(result.columns));
         results.push(result);
     }
 
     return new Buffer(JSON.stringify(results));
-}
-
-InfluxUdp.prototype.keysToValues = function(columns) {
-    return function(values) {
-        return columns.map(function(column) {
-            return values[column];
-        });
-    };
 }
 
 InfluxUdp.prototype.send = function influxSend(points) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,52 @@
 var dgram = require('dgram');
+var util = require('util');
 
 var _ = require('lodash');
+
+var timeScales = {
+    microsecond: 1e3,
+    millisecond: 1e6,
+    nanosecond: 1,
+    second: 1e9
+};
 
 var InfluxUdp = function influxUdp(opts) {
     opts = opts || {};
     this.host = opts.host || '127.0.0.1';
     this.port = opts.port || 4444;
-    this.socket = dgram.createSocket('udp4');
+    this.protocol = opts.protocol || 'line';
+    this.reportTime = opts.reportTime || true;
+    this.socket = dgram.createSocket(opts.socketType || 'udp4');
+    this.timeScale = timeScales[opts.timeScale] || 1;
+
+    if (!messageBuilders[this.protocol]) {
+        throw new Error('Invalid protocol');
+    }
 };
 
-function keysToValues(columns) {
-    return function(values) {
-        return columns.map(function(column) {
-            return values[column];
-        });
-    };
+function convertPointToLine(name, point) {
+    time = (point.time || new Date()).valueOf();
+    delete point.time;
+
+    return name +
+        _.reduce(point, function(line, value, key) {
+            return line + util.format(' %s=%s ', key, value);
+        }, '') +
+        this.reportTime ? ' ' + (time * this.timeScale) : '';
 }
 
-InfluxUdp.prototype.send = function influxSend(points) {
+function lineProtocol(points) {
+    return new Buffer(
+        _.reduce(points, function(arr, value, key) {
+            if (Array.isArray(value)) {
+                return arr.concat(value.map(_.partial(convertPointToLine, key)));
+            }
+            return arr.concat(convertPointToLine(key, value));
+        }, []).join('\n')
+    );
+}
+
+function jsonProtocol(points) {
     var results = [];
 
     for (var name in points) {
@@ -31,14 +60,48 @@ InfluxUdp.prototype.send = function influxSend(points) {
             values = [values];
         }
 
+        if (this.reportTime) {
+            values.forEach(function(value) {
+                if (!value.time) {
+                    value.time = (value.time || new Date()).valueOf();
+                }
+            });
+        } else {
+            values.forEach(function(value) {
+                delete value.time;
+            });
+        }
+
         result.points = values.map(keysToValues(result.columns));
         results.push(result);
     }
 
-    var message = new Buffer(JSON.stringify(results));
+    return new Buffer(JSON.stringify(results));
+}
+
+function keysToValues(columns) {
+    return function(values) {
+        return columns.map(function(column) {
+            return values[column];
+        });
+    };
+}
+
+var messageBuilders = {
+    json: jsonProtocol,
+    line: lineProtocol
+};
+
+InfluxUdp.prototype.send = function influxSend(points) {
+    if (!messageBuilders[this.protocol]) {
+        throw new Error('Invalid protocol');
+    }
+    var message = messageBuilders[this.protocol](points);
+
     this.socket.send(message, 0, message.length, this.port, this.host);
 
     return results;
 };
+
 
 module.exports = InfluxUdp;

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,28 +34,29 @@ InfluxUdp.prototype.convertObjectToKV = function(obj) {
     }).join(',');
 }
 
-InfluxUdp.prototype.convertPointToLine = function(seriesName, point) {
-    var time = (point.time || new Date()).valueOf();
-    delete point.time;
-    return [
-        seriesName,
-        point.tags ? ',' : '',
-        this.convertObjectToKV(point.tags || {}),
-        ' ',
-        this.convertObjectToKV(point.values),
-        this.reportTime ? ' ' + (time * this.timeScale) : ''
-    ].join('');
-}
-
 InfluxUdp.prototype.lineProtocol = function(points) {
     var self = this;
+
+    var convertPointToLine = function(seriesName, point) {
+        var time = (point.time || new Date()).valueOf();
+        delete point.time;
+        return [
+            seriesName,
+            point.tags ? ',' : '',
+            self.convertObjectToKV(point.tags || {}),
+            ' ',
+            self.convertObjectToKV(point.values),
+            self.reportTime ? ' ' + (time * self.timeScale) : ''
+        ].join('');
+    }
+
     return new Buffer(
         _.reduce(points, function(arr, value, key) {
-            var convert = _.bind(_.partial(self.convertPointToLine, key), self);
+            var convert = _.bind(_.partial(convertPointToLine, key), self);
             if (Array.isArray(value)) {
                 return arr.concat(value.map(convert));
             }
-            return arr.concat(self.convertPointToLine(key, value));
+            return arr.concat(convertPointToLine(key, value));
         }, []).join('\n')
     );
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,24 +29,24 @@ var InfluxUdp = function influxUdp(opts) {
     }
 };
 
-InfluxUdp.prototype.convertObjectToKV = function(obj) {
-    return Object.keys(obj).map(function(key) {
-        return key + '=' + obj[key]
-    }).join(',');
-}
-
 InfluxUdp.prototype.lineProtocol = function(points) {
     var self = this;
 
-    var convertPointToLine = function(seriesName, point) {
+    function convertObjectToKV(obj) {
+        return Object.keys(obj).map(function(key) {
+            return key + '=' + obj[key]
+        }).join(',');
+    }
+
+    function convertPointToLine(seriesName, point) {
         var time = (point.time || new Date()).valueOf();
         delete point.time;
         return [
             seriesName,
             point.tags ? ',' : '',
-            self.convertObjectToKV(point.tags || {}),
+            convertObjectToKV(point.tags || {}),
             ' ',
-            self.convertObjectToKV(point.values),
+            convertObjectToKV(point.values),
             self.reportTime ? ' ' + (time * self.timeScale) : ''
         ].join('');
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,37 +16,51 @@ var InfluxUdp = function influxUdp(opts) {
     this.port = opts.port || 4444;
     this.protocol = opts.protocol || 'line';
     this.reportTime = opts.reportTime || true;
-    this.socket = dgram.createSocket(opts.socketType || 'udp4');
+    this.socketType = opts.socketType || 'udp4';
     this.timeScale = timeScales[opts.timeScale] || 1;
 
-    if (!messageBuilders[this.protocol]) {
-        throw new Error('Invalid protocol');
+    this.encode = this.protocol == 'line' ? this.lineProtocol :
+                  this.protocol == 'json' ? this.jsonProtocol :
+                  undefined;
+
+    if (!this.encode) {
+        throw new Error('Invalid protocol: ' + this.encode);
     }
 };
 
-function convertPointToLine(name, point) {
-    time = (point.time || new Date()).valueOf();
-    delete point.time;
-
-    return name +
-        _.reduce(point, function(line, value, key) {
-            return line + util.format(' %s=%s ', key, value);
-        }, '') +
-        this.reportTime ? ' ' + (time * this.timeScale) : '';
+InfluxUdp.prototype.convertObjectToKV = function(obj) {
+    return Object.keys(obj).map(function(key) {
+        return key + '=' + obj[key]
+    }).join(',');
 }
 
-function lineProtocol(points) {
+InfluxUdp.prototype.convertPointToLine = function(seriesName, point) {
+    var time = (point.time || new Date()).valueOf();
+    delete point.time;
+    return [
+        seriesName,
+        point.tags ? ',' : '',
+        this.convertObjectToKV(point.tags || {}),
+        ' ',
+        this.convertObjectToKV(point.values),
+        this.reportTime ? ' ' + (time * this.timeScale) : ''
+    ].join('');
+}
+
+InfluxUdp.prototype.lineProtocol = function(points) {
+    var self = this;
     return new Buffer(
         _.reduce(points, function(arr, value, key) {
+            var convert = _.bind(_.partial(self.convertPointToLine, key), self);
             if (Array.isArray(value)) {
-                return arr.concat(value.map(_.partial(convertPointToLine, key)));
+                return arr.concat(value.map(convert));
             }
-            return arr.concat(convertPointToLine(key, value));
+            return arr.concat(self.convertPointToLine(key, value));
         }, []).join('\n')
     );
 }
 
-function jsonProtocol(points) {
+InfluxUdp.prototype.jsonProtocol = function(points) {
     var results = [];
 
     for (var name in points) {
@@ -72,14 +86,14 @@ function jsonProtocol(points) {
             });
         }
 
-        result.points = values.map(keysToValues(result.columns));
+        result.points = values.map(this.keysToValues(result.columns));
         results.push(result);
     }
 
     return new Buffer(JSON.stringify(results));
 }
 
-function keysToValues(columns) {
+InfluxUdp.prototype.keysToValues = function(columns) {
     return function(values) {
         return columns.map(function(column) {
             return values[column];
@@ -87,21 +101,13 @@ function keysToValues(columns) {
     };
 }
 
-var messageBuilders = {
-    json: jsonProtocol,
-    line: lineProtocol
-};
-
 InfluxUdp.prototype.send = function influxSend(points) {
-    if (!messageBuilders[this.protocol]) {
-        throw new Error('Invalid protocol');
-    }
-    var message = messageBuilders[this.protocol](points);
+    var message = this.encode(points);
+    var socket = dgram.createSocket(this.socketType);
 
-    this.socket.send(message, 0, message.length, this.port, this.host);
-
-    return results;
+    socket.send(message, 0, message.length, this.port, this.host, function () {
+        socket.close();
+    });
 };
-
 
 module.exports = InfluxUdp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2195 @@
+{
+    "name": "influx-udp",
+    "version": "2.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "abbrev": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+            "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+            "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+            "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "json-schema-traverse": "0.3.1",
+                "json-stable-stringify": "1.0.1"
+            }
+        },
+        "ajv-keywords": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+            "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-escapes": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+            "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true,
+            "requires": {
+                "callsites": "0.2.0"
+            }
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true,
+            "optional": true
+        },
+        "caseless": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+            }
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+            "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+            "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+            }
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "coveralls": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
+            "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+            "dev": true,
+            "requires": {
+                "js-yaml": "3.6.1",
+                "lcov-parse": "0.0.10",
+                "log-driver": "1.2.5",
+                "minimist": "1.2.0",
+                "request": "2.79.0"
+            }
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            }
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "debug": {
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true,
+            "optional": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true,
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.1"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+            "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escodegen": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+            "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+            "dev": true,
+            "requires": {
+                "esprima": "2.7.3",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                    "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.5.0.tgz",
+            "integrity": "sha1-u3XTuL3pf7XhPvzVOXRGd/6wGcM=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.2.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.1.0",
+                "concat-stream": "1.6.0",
+                "cross-spawn": "5.1.0",
+                "debug": "2.6.8",
+                "doctrine": "2.0.0",
+                "eslint-scope": "3.7.1",
+                "espree": "3.5.0",
+                "esquery": "1.0.0",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "9.18.0",
+                "ignore": "3.3.4",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.2.2",
+                "is-resolvable": "1.0.0",
+                "js-yaml": "3.9.1",
+                "json-stable-stringify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.4",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "4.0.0",
+                "progress": "2.0.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.4.1",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "4.0.1",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.2.1"
+                    }
+                },
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "3.9.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+                    "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "1.0.9",
+                        "esprima": "4.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                    "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "dev": true,
+            "requires": {
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+            }
+        },
+        "espree": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+            "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+            "dev": true,
+            "requires": {
+                "acorn": "5.1.1",
+                "acorn-jsx": "3.0.1"
+            }
+        },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+            "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+            "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0",
+                "object-assign": "4.1.1"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "external-editor": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+            "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.18",
+                "jschardet": "1.5.1",
+                "tmp": "0.0.31"
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "1.2.2",
+                "object-assign": "4.1.1"
+            }
+        },
+        "flat-cache": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+            "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+            "dev": true,
+            "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.16"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
+            "requires": {
+                "is-property": "1.0.2"
+            }
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "globals": {
+            "version": "9.18.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "dev": true
+        },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true,
+            "requires": {
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "har-validator": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.11.0",
+                "is-my-json-valid": "2.16.1",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+            }
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+            "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+            "dev": true
+        },
+        "ignore": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.4.tgz",
+            "integrity": "sha512-KjHyHxUgicfgFiTJaIA9DoeY3TIQz5thaKqm35re7RTVVB7zjF1fTMIDMXM4GUUBipR4FW8BvGnA115pZ/AxQQ==",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.2.tgz",
+            "integrity": "sha512-bTKLzEHJVATimZO/YFdLrom0lRx1BHfRYskFHfIMVkGdp8+dIZaxuU+4yrsS1lcu6YWywVQVVsfvdwESzbeqHw==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "2.0.0",
+                "chalk": "2.1.0",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.0.4",
+                "figures": "2.0.0",
+                "lodash": "4.17.4",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+                    "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.2.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                    "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                }
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-my-json-valid": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+            "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+            "dev": true,
+            "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+            "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "1.0.0"
+            }
+        },
+        "is-path-inside": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+            "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+            "dev": true,
+            "requires": {
+                "tryit": "1.0.3"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "istanbul": {
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+            "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1.0.9",
+                "async": "1.5.2",
+                "escodegen": "1.8.1",
+                "esprima": "2.7.3",
+                "glob": "5.0.15",
+                "handlebars": "4.0.10",
+                "js-yaml": "3.6.1",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "once": "1.4.0",
+                "resolve": "1.1.7",
+                "supports-color": "3.2.3",
+                "which": "1.3.0",
+                "wordwrap": "1.0.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+            "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "jschardet": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+            "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json3": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.5"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true,
+            "optional": true
+        },
+        "lcov-parse": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+            "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
+        },
+        "lodash": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+            "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "lodash._baseassign": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keys": "3.1.2"
+            }
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basecreate": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+            "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash.create": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+            "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+            "dev": true,
+            "requires": {
+                "lodash._baseassign": "3.2.0",
+                "lodash._basecreate": "3.0.3",
+                "lodash._isiterateecall": "3.0.9"
+            }
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
+        },
+        "log-driver": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+            "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
+        },
+        "mime-db": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+            "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+            "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.29.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "mocha": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+            "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.9.0",
+                "debug": "2.6.8",
+                "diff": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.1",
+                "growl": "1.9.2",
+                "json3": "3.3.2",
+                "lodash.create": "3.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "3.1.2"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                    "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                    "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                    "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "mock-udp": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/mock-udp/-/mock-udp-0.1.1.tgz",
+            "integrity": "sha1-JLXkdwdjXDSos/Cvzv0UC36yhLU=",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1.0.9"
+            }
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.1.0"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "pluralize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+            "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.79.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+            "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.16",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.2",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.4.3",
+                "uuid": "3.1.0"
+            }
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
+            "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+            }
+        },
+        "resolve": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+            "dev": true
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "2.1.0"
+            }
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "4.0.8"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
+        },
+        "source-map": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+            "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "amdefine": "1.0.1"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "table": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
+            "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+            "dev": true,
+            "requires": {
+                "ajv": "4.11.8",
+                "ajv-keywords": "1.5.1",
+                "chalk": "1.1.3",
+                "lodash": "4.17.4",
+                "slice-ansi": "0.0.4",
+                "string-width": "2.1.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "4.11.8",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+                    "dev": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                }
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+            "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
+        },
+        "tryit": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+            "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "dev": true,
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true,
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
     "dependencies": {
         "lodash": "3.10.x"
     },
+    "devDependencies": {
+        "mocha": "2.0.1",
+        "mock-udp": "0.1.1"
+    },
+    "scripts": {
+        "test": "mocha --ui qunit --reporter list --bail --check-leaks test/index.js"
+    },
     "keywords": ["influx", "influxdb", "udp" ],
     "license": "Apache-2.0",
     "main": "./lib",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     },
     "devDependencies": {
         "coveralls": "*",
+        "eslint": "^4.5.0",
         "istanbul": "*",
         "mocha": "*",
         "mock-udp": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     },
     "scripts": {
         "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-        "test": "mocha --ui qunit --reporter list --bail --check-leaks test/index.js"
+        "test": "mocha --ui qunit --reporter list --bail --check-leaks test/index.js",
+        "fixlint": "eslint lib --ext .js --fix"
     },
     "keywords": [
         "influx",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "mock-udp": "0.1.1"
     },
     "scripts": {
-        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --ui qunit --reporter list --bail --check-leaks && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
         "test": "mocha --ui qunit --reporter list --bail --check-leaks test/index.js",
         "fixlint": "eslint lib --ext .js --fix"
     },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
     "description": "UDP-based write utility for InfluxDB",
     "dependencies": {
-        "lodash": "2.4.x"
+        "lodash": "3.10.x"
     },
     "keywords": ["influx", "influxdb", "udp" ],
     "license": "Apache-2.0",
     "main": "./lib",
     "name": "influx-udp",
     "repository": "git://github.com/mediocre/node-influx-udp.git",
-    "version": "1.0.1"
+    "version": "2.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "main": "./lib",
     "name": "influx-udp",
     "repository": "git://github.com/mediocre/node-influx-udp.git",
-    "version": "2.0.0"
+    "version": "1.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,20 @@
         "lodash": "3.10.x"
     },
     "devDependencies": {
-        "mocha": "2.0.1",
+        "coveralls": "*",
+        "istanbul": "*",
+        "mocha": "*",
         "mock-udp": "0.1.1"
     },
     "scripts": {
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
         "test": "mocha --ui qunit --reporter list --bail --check-leaks test/index.js"
     },
-    "keywords": ["influx", "influxdb", "udp" ],
+    "keywords": [
+        "influx",
+        "influxdb",
+        "udp"
+    ],
     "license": "Apache-2.0",
     "main": "./lib",
     "name": "influx-udp",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,72 @@
+var mock_udp = require('mock-udp');
+var assert = require('assert');
+
+var InfluxUdp = require('../');
+
+suite('influx-udp');
+
+test('should send a single data point via UDP', function(done) {
+   var influx_udp = new InfluxUdp({
+     host: 'example.com',
+     port: '8086',
+     protocol: 'line',
+     reportTime: true,
+   });
+
+    var scope = mock_udp('example.com:8086');
+
+    influx_udp.send({
+        'metric1': [
+            {
+                values: { fkey: "fval", fkey2: "fval2" },
+                tags: { tkey1: "tval1", tkey2: "tval2" },
+                time: 1468430065292
+            }
+        ]
+    });
+
+    assert.equal(
+        scope.buffer.toString(),
+        "metric1,tkey1=tval1,tkey2=tval2 fkey=fval,fkey2=fval2 1468430065292"
+    );
+    scope.done();
+    done();
+});
+
+test('should send a single data point via UDP-json', function(done) {
+   var influx_udp = new InfluxUdp({
+     host: 'example.com',
+     port: '8086',
+     protocol: 'json',
+     reportTime: true,
+   });
+
+    var scope = mock_udp('example.com:8086');
+
+    influx_udp.send({
+        'metric1': [
+            {
+                values: { fkey: "fval", fkey2: "fval2" },
+                tags: { tkey1: "tval1", tkey2: "tval2" },
+                time: 1468430065292
+            }
+        ]
+    });
+
+    assert.deepEqual(
+        JSON.parse(scope.buffer.toString()),
+        [{
+            "name": "metric1",
+            "columns": ["values", "tags", "time"],
+            "points": [
+                [
+                    {"fkey": "fval", "fkey2": "fval2"},
+                    {"tkey1": "tval1", "tkey2": "tval2"},
+                    1468430065292 
+                ]
+            ]
+        }]
+    );
+    scope.done();
+    done();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -27,11 +27,39 @@ test('should send a single data point via UDP', function(done) {
 
     assert.equal(
         scope.buffer.toString(),
-        "metric1,tkey1=tval1,tkey2=tval2 fkey=fval,fkey2=fval2 1468430065292"
+        "metric1,tkey1=tval1,tkey2=tval2 fkey=\"fval\",fkey2=\"fval2\" 1468430065292"
     );
     scope.done();
     done();
 });
+
+test('should properly format typed values', function(done) {
+   var influx_udp = new InfluxUdp({
+     host: 'example.com',
+     port: '8086',
+     protocol: 'line',
+     reportTime: true,
+   });
+
+    var scope = mock_udp('example.com:8086');
+
+    influx_udp.send({
+        'metric1': [
+            {
+                values: { fkey: "string_val", fkey2: true, fkey3: 12345 },
+                tags: { tkey1: "tval1", tkey2: "tval2" },
+                time: 1468430065292
+            }
+        ]
+    });
+
+    assert.equal(
+        scope.buffer.toString(),
+        "metric1,tkey1=tval1,tkey2=tval2 fkey=\"string_val\",fkey2=true,fkey3=12345 1468430065292"
+    );
+    scope.done();
+    done();
+})
 
 test('should send a single data point via UDP-json', function(done) {
    var influx_udp = new InfluxUdp({
@@ -62,7 +90,7 @@ test('should send a single data point via UDP-json', function(done) {
                 [
                     {"fkey": "fval", "fkey2": "fval2"},
                     {"tkey1": "tval1", "tkey2": "tval2"},
-                    1468430065292 
+                    1468430065292
                 ]
             ]
         }]

--- a/test/index.js
+++ b/test/index.js
@@ -98,3 +98,35 @@ test('should send a single data point via UDP-json', function(done) {
     scope.done();
     done();
 });
+
+test('writePoints method behaves like in node-influx', function(done) {
+   var influx_udp = new InfluxUdp({
+     host: 'example.com',
+     port: '8086',
+     protocol: 'line',
+   });
+
+    var scope = mock_udp('example.com:8086');
+
+    // example from https://github.com/node-influx/node-influx#writepoints
+    var points = [
+      [{value: 232}, { tag: 'foobar'}],
+      [{value: 212}, { someothertag: 'baz'}],
+      [123, { foobar: 'baz'}],
+      [{value: 122, time: 1234567}]
+    ]
+
+    influx_udp.writePoints('seriesname', points);
+
+    assert.ok(
+        scope.buffer.toString().match(new RegExp(
+            "seriesname,tag=foobar value=232 [0-9]+\n" +
+            "seriesname,someothertag=baz value=212 [0-9]+\n" +
+            "seriesname,foobar=baz value=123 [0-9]+\n" +
+            "seriesname value=122 1234567"
+        )),
+        scope.buffer.toString()
+    );
+    scope.done();
+    done();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ test('should send a single data point via UDP', function(done) {
      host: 'example.com',
      port: '8086',
      protocol: 'line',
-     reportTime: true,
+     reportTime: true
    });
 
     var scope = mock_udp('example.com:8086');
@@ -18,8 +18,8 @@ test('should send a single data point via UDP', function(done) {
     influx_udp.send({
         'metric1': [
             {
-                values: { fkey: "fval", fkey2: "fval2" },
-                tags: { tkey1: "tval1", tkey2: "tval2" },
+                values: { fkey: 'fval', fkey2: 'fval2' },
+                tags: { tkey1: 'tval1', tkey2: 'tval2' },
                 time: 1468430065292
             }
         ]
@@ -27,8 +27,9 @@ test('should send a single data point via UDP', function(done) {
 
     assert.equal(
         scope.buffer.toString(),
-        "metric1,tkey1=tval1,tkey2=tval2 fkey=\"fval\",fkey2=\"fval2\" 1468430065292"
+        'metric1,tkey1=tval1,tkey2=tval2 fkey="fval",fkey2="fval2" 1468430065292'
     );
+
     scope.done();
     done();
 });
@@ -38,7 +39,7 @@ test('should properly format typed values', function(done) {
      host: 'example.com',
      port: '8086',
      protocol: 'line',
-     reportTime: true,
+     reportTime: true
    });
 
     var scope = mock_udp('example.com:8086');
@@ -46,8 +47,8 @@ test('should properly format typed values', function(done) {
     influx_udp.send({
         'metric1': [
             {
-                values: { fkey: "string_val", fkey2: true, fkey3: 12345 },
-                tags: { tkey1: "tval1", tkey2: "tval2" },
+                values: { fkey: 'string_val', fkey2: true, fkey3: 12345 },
+                tags: { tkey1: 'tval1', tkey2: 'tval2' },
                 time: 1468430065292
             }
         ]
@@ -55,18 +56,19 @@ test('should properly format typed values', function(done) {
 
     assert.equal(
         scope.buffer.toString(),
-        "metric1,tkey1=tval1,tkey2=tval2 fkey=\"string_val\",fkey2=true,fkey3=12345 1468430065292"
+        'metric1,tkey1=tval1,tkey2=tval2 fkey="string_val",fkey2=true,fkey3=12345 1468430065292'
     );
+
     scope.done();
     done();
-})
+});
 
 test('should send a single data point via UDP-json', function(done) {
    var influx_udp = new InfluxUdp({
      host: 'example.com',
      port: '8086',
      protocol: 'json',
-     reportTime: true,
+     reportTime: true
    });
 
     var scope = mock_udp('example.com:8086');
@@ -74,8 +76,8 @@ test('should send a single data point via UDP-json', function(done) {
     influx_udp.send({
         'metric1': [
             {
-                values: { fkey: "fval", fkey2: "fval2" },
-                tags: { tkey1: "tval1", tkey2: "tval2" },
+                values: { fkey: 'fval', fkey2: 'fval2' },
+                tags: { tkey1: 'tval1', tkey2: 'tval2' },
                 time: 1468430065292
             }
         ]
@@ -84,17 +86,18 @@ test('should send a single data point via UDP-json', function(done) {
     assert.deepEqual(
         JSON.parse(scope.buffer.toString()),
         [{
-            "name": "metric1",
-            "columns": ["values", "tags", "time"],
-            "points": [
+            name: 'metric1',
+            columns: ['values', 'tags', 'time'],
+            points: [
                 [
-                    {"fkey": "fval", "fkey2": "fval2"},
-                    {"tkey1": "tval1", "tkey2": "tval2"},
+                    { fkey: 'fval', fkey2: 'fval2' },
+                    { tkey1: 'tval1', tkey2: 'tval2' },
                     1468430065292
                 ]
             ]
         }]
     );
+
     scope.done();
     done();
 });
@@ -103,30 +106,31 @@ test('writePoints method behaves like in node-influx', function(done) {
    var influx_udp = new InfluxUdp({
      host: 'example.com',
      port: '8086',
-     protocol: 'line',
+     protocol: 'line'
    });
 
     var scope = mock_udp('example.com:8086');
 
     // example from https://github.com/node-influx/node-influx#writepoints
     var points = [
-      [{value: 232}, { tag: 'foobar'}],
-      [{value: 212}, { someothertag: 'baz'}],
-      [123, { foobar: 'baz'}],
-      [{value: 122, time: 1234567}]
-    ]
+      [{ value: 232 }, { tag: 'foobar' }],
+      [{ value: 212 }, { someothertag: 'baz' }],
+      [123, { foobar: 'baz' }],
+      [{ value: 122, time: 1234567 }]
+  ];
 
     influx_udp.writePoints('seriesname', points);
 
     assert.ok(
         scope.buffer.toString().match(new RegExp(
-            "seriesname,tag=foobar value=232 [0-9]+\n" +
-            "seriesname,someothertag=baz value=212 [0-9]+\n" +
-            "seriesname,foobar=baz value=123 [0-9]+\n" +
-            "seriesname value=122 1234567"
+            'seriesname,tag=foobar value=232 [0-9]+\n' +
+            'seriesname,someothertag=baz value=212 [0-9]+\n' +
+            'seriesname,foobar=baz value=123 [0-9]+\n' +
+            'seriesname value=122 1234567'
         )),
         scope.buffer.toString()
     );
+
     scope.done();
     done();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,12 @@ var InfluxUdp = require('../');
 suite('influx-udp');
 
 test('should send a single data point via UDP', function(done) {
-   var influx_udp = new InfluxUdp({
-     host: 'example.com',
-     port: '8086',
-     protocol: 'line',
-     reportTime: true
-   });
+    var influx_udp = new InfluxUdp({
+        host: 'example.com',
+        port: '8086',
+        protocol: 'line',
+        reportTime: true
+    });
 
     var scope = mock_udp('example.com:8086');
 
@@ -35,12 +35,12 @@ test('should send a single data point via UDP', function(done) {
 });
 
 test('should properly format typed values', function(done) {
-   var influx_udp = new InfluxUdp({
-     host: 'example.com',
-     port: '8086',
-     protocol: 'line',
-     reportTime: true
-   });
+    var influx_udp = new InfluxUdp({
+        host: 'example.com',
+        port: '8086',
+        protocol: 'line',
+        reportTime: true
+    });
 
     var scope = mock_udp('example.com:8086');
 
@@ -64,12 +64,12 @@ test('should properly format typed values', function(done) {
 });
 
 test('should send a single data point via UDP-json', function(done) {
-   var influx_udp = new InfluxUdp({
-     host: 'example.com',
-     port: '8086',
-     protocol: 'json',
-     reportTime: true
-   });
+    var influx_udp = new InfluxUdp({
+        host: 'example.com',
+        port: '8086',
+        protocol: 'json',
+        reportTime: true
+    });
 
     var scope = mock_udp('example.com:8086');
 
@@ -103,21 +103,21 @@ test('should send a single data point via UDP-json', function(done) {
 });
 
 test('writePoints method behaves like in node-influx', function(done) {
-   var influx_udp = new InfluxUdp({
-     host: 'example.com',
-     port: '8086',
-     protocol: 'line'
-   });
+    var influx_udp = new InfluxUdp({
+        host: 'example.com',
+        port: '8086',
+        protocol: 'line'
+    });
 
     var scope = mock_udp('example.com:8086');
 
     // example from https://github.com/node-influx/node-influx#writepoints
     var points = [
-      [{ value: 232 }, { tag: 'foobar' }],
-      [{ value: 212 }, { someothertag: 'baz' }],
-      [123, { foobar: 'baz' }],
-      [{ value: 122, time: 1234567 }]
-  ];
+        [{ value: 232 }, { tag: 'foobar' }],
+        [{ value: 212 }, { someothertag: 'baz' }],
+        [123, { foobar: 'baz' }],
+        [{ value: 122, time: 1234567 }]
+    ];
 
     influx_udp.writePoints('seriesname', points);
 


### PR DESCRIPTION
- add support for InfluxDB 0.9
- conform to same API as node-influx lib
- add UDP support
- add tests, eslint, travis, and coveralls
